### PR TITLE
refactor: reorganize router structure for better endpoint organization

### DIFF
--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -18,11 +18,12 @@ async fn index() -> impl IntoResponse {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let state = libpasskey::passkey::app_state().await?;
+    let passkey_state = libpasskey::passkey::app_state().await?;
 
     let app = Router::new()
         .route("/", get(index))
-        .merge(routes::create_router(state));
+        .nest("/auth", routes::router_auth(passkey_state.clone()))
+        .nest("/register", routes::router_register(passkey_state.clone()));
 
     println!("Starting server on http://localhost:3001");
     let listener = tokio::net::TcpListener::bind("0.0.0.0:3001").await?;

--- a/demo/src/routes.rs
+++ b/demo/src/routes.rs
@@ -8,12 +8,17 @@ use libpasskey::{
     AppState,
 };
 
-pub fn create_router(state: AppState) -> Router {
+pub fn router_register(state: AppState) -> Router {
     Router::new()
-        .route("/register/start", post(handle_start_registration))
-        .route("/register/finish", post(handle_finish_registration))
-        .route("/auth/start", post(handle_start_authentication))
-        .route("/auth/finish", post(handle_finish_authentication))
+        .route("/start", post(handle_start_registration))
+        .route("/finish", post(handle_finish_registration))
+        .with_state(state)
+}
+
+pub fn router_auth(state: AppState) -> Router {
+    Router::new()
+        .route("/start", post(handle_start_authentication))
+        .route("/finish", post(handle_finish_authentication))
         .with_state(state)
 }
 


### PR DESCRIPTION
- Split routes into separate auth and register routers
- Use Router::nest() for cleaner URL hierarchy
- Rename state variable to passkey_state for clarity