### PR TITLE
refactor: simplify storage implementation to memory-only

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ edition = "2021"
 
 [workspace.dependencies]
 libpasskey = { path = "./libpasskey" }
-axum = { version = "0.8.1", features = ["http2", "macros", "multipart"] }
-tokio = { version = "1.42.0", features = ["bytes", "fs", "io-std", "macros", "net", "parking_lot", "rt-multi-thread", "signal", "sync", "time", "tracing"] }
+axum = { version = "0.8", features = ["http2", "macros", "multipart"] }
+tokio = { version = "1.42", features = ["bytes", "fs", "io-std", "macros", "net", "parking_lot", "rt-multi-thread", "signal", "sync", "time", "tracing"] }

--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -11,3 +11,4 @@ axum-core = "0.5.0"
 tokio = { workspace = true }
 
 libpasskey.workspace = true
+serde_json = "1.0.138"

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -5,6 +5,11 @@ use axum::{
     routing::{get, Router},
 };
 use axum_core::response::IntoResponse;
+use libpasskey::{
+    storage::{ChallengeStoreType, CredentialStoreType},
+    AppState,
+};
+
 mod routes;
 
 #[derive(Template)]
@@ -18,7 +23,11 @@ async fn index() -> impl IntoResponse {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let passkey_state = libpasskey::passkey::app_state().await?;
+    let passkey_state = AppState::with_store_types(
+        ChallengeStoreType::Memory,  // Use memory for challenges (temporary data)
+        CredentialStoreType::Memory, // Use memory for credentials (for demo purposes)
+    )
+    .await?;
 
     let app = Router::new()
         .route("/", get(index))

--- a/demo/src/routes.rs
+++ b/demo/src/routes.rs
@@ -1,10 +1,19 @@
-use axum::http::StatusCode;
-use axum::{extract::State, routing::post, Json, Router};
+use axum::{
+    extract::{Json, State},
+    http::StatusCode,
+    routing::post,
+    Router,
+};
 use libpasskey::{
-    auth::{
-        start_authentication, verify_authentication, AuthenticationOptions, AuthenticatorResponse,
+    passkey::{
+        auth::{
+            start_authentication, verify_authentication, AuthenticationOptions,
+            AuthenticatorResponse,
+        },
+        register::{
+            finish_registration, start_registration, RegisterCredential, RegistrationOptions,
+        },
     },
-    register::{finish_registration, start_registration, RegisterCredential, RegistrationOptions},
     AppState,
 };
 
@@ -26,20 +35,28 @@ async fn handle_start_registration(
     State(state): State<AppState>,
     Json(username): Json<String>,
 ) -> Json<RegistrationOptions> {
-    Json(start_registration(&state, username).await)
+    Json(
+        start_registration(&state, username)
+            .await
+            .expect("Failed to start registration"),
+    )
 }
 
 async fn handle_finish_registration(
     State(state): State<AppState>,
     Json(reg_data): Json<RegisterCredential>,
-) -> Result<&'static str, (StatusCode, String)> {
+) -> Result<String, (StatusCode, String)> {
     finish_registration(&state, reg_data)
         .await
         .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))
 }
 
 async fn handle_start_authentication(State(state): State<AppState>) -> Json<AuthenticationOptions> {
-    Json(start_authentication(&state).await)
+    Json(
+        start_authentication(&state)
+            .await
+            .expect("Failed to start authentication"),
+    )
 }
 
 async fn handle_finish_authentication(

--- a/libpasskey/Cargo.toml
+++ b/libpasskey/Cargo.toml
@@ -4,7 +4,7 @@ version = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-anyhow = "1.0.95"
+async-trait = "0.1"
 axum = { workspace = true }
 base64 = "0.22.1"
 ciborium = "0.2.2"
@@ -13,8 +13,21 @@ oid-registry = "0.8.0"
 ring = { version = "0.17.8", features = ["std"] }
 serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.133"
+sqlx = { version = "0.8", features = [
+    "any",
+    "chrono", 
+    "json", 
+    "macros",
+    "mysql", 
+    "postgres", 
+    "regexp", 
+    "runtime-tokio-native-tls", 
+    "runtime-tokio-rustls", 
+    "sqlite",
+    "runtime-async-std-native-tls"
+], default-features = false }
 thiserror = "2.0.11"
 tokio = { workspace = true }
 uuid = { version = "1.11.0", features = ["atomic", "md5", "sha1", "v4"] }
 webpki = { version = "0.22.4", features = ["std"] }
-x509-parser = { version = "0.16.0", features = ["validate", "verify"] }
+x509-parser = { version = "0.17.0", features = ["validate", "verify"] }

--- a/libpasskey/src/config.rs
+++ b/libpasskey/src/config.rs
@@ -7,6 +7,7 @@ use crate::errors::PasskeyError;
 pub struct Config {
     pub origin: String,
     pub rp_id: String,
+    pub rp_name: String,
     pub authenticator_selection: AuthenticatorSelection,
     pub timeout: u32,
     pub challenge_timeout_seconds: u64,
@@ -36,6 +37,8 @@ impl Config {
             .next()
             .unwrap_or(&origin)
             .to_string();
+
+        let rp_name = env::var("PASSKEY_RP_NAME").unwrap_or(origin.clone());
 
         let timeout = env::var("PASSKEY_TIMEOUT")
             .map(|v| v.parse::<u32>())
@@ -114,6 +117,7 @@ impl Config {
         Ok(Config {
             origin,
             rp_id,
+            rp_name,
             timeout,
             challenge_timeout_seconds: challenge_timeout,
             authenticator_selection: AuthenticatorSelection {

--- a/libpasskey/src/errors.rs
+++ b/libpasskey/src/errors.rs
@@ -26,6 +26,9 @@ pub enum PasskeyError {
     #[error("Verification error: {0}")]
     Verification(String),
 
+    #[error("Not found error: {0}")]
+    NotFound(String),
+
     #[error("Crypto error: {0}")]
     Crypto(String),
 

--- a/libpasskey/src/lib.rs
+++ b/libpasskey/src/lib.rs
@@ -1,8 +1,16 @@
 pub mod config;
 pub mod errors;
 pub mod passkey;
+pub mod storage;
 
-// pub use crate::passkey::auth::*;
-pub use crate::passkey::auth;
-pub use crate::passkey::register;
-pub use crate::passkey::AppState;
+pub use passkey::{auth, register, AppState};
+pub use storage::{
+    ChallengeStore,
+    ChallengeStoreType,
+    CredentialStore,
+    CredentialStoreType,
+    InMemoryChallengeStore,
+    InMemoryCredentialStore,
+    // PostgresChallengeStore,
+    // PostgresCredentialStore, SqliteChallengeStore, SqliteCredentialStore,
+};

--- a/libpasskey/src/storage.rs
+++ b/libpasskey/src/storage.rs
@@ -1,0 +1,92 @@
+use crate::errors::PasskeyError;
+use crate::passkey::{StoredChallenge, StoredCredential};
+use async_trait::async_trait;
+
+pub mod memory;
+// pub mod postgres;
+// pub mod sqlite;
+
+pub use memory::{InMemoryChallengeStore, InMemoryCredentialStore};
+// pub use postgres::{PostgresChallengeStore, PostgresCredentialStore};
+// pub use sqlite::{SqliteChallengeStore, SqliteCredentialStore};
+
+#[derive(Clone, Debug)]
+pub enum ChallengeStoreType {
+    Memory,
+    // Sqlite { path: String },
+    // Postgres { url: String },
+}
+
+#[derive(Clone, Debug)]
+pub enum CredentialStoreType {
+    Memory,
+    // Sqlite { path: String },
+    // Postgres { url: String },
+}
+
+impl ChallengeStoreType {
+    pub async fn create_store(&self) -> Result<Box<dyn ChallengeStore>, PasskeyError> {
+        match self {
+            ChallengeStoreType::Memory => Ok(Box::new(InMemoryChallengeStore::default())),
+            // ChallengeStoreType::Sqlite { path } => {
+            //     Ok(Box::new(SqliteChallengeStore::connect(path).await?))
+            // }
+            // ChallengeStoreType::Postgres { url } => {
+            //     Ok(Box::new(PostgresChallengeStore::new(url).await?))
+            // }
+        }
+    }
+}
+
+impl CredentialStoreType {
+    pub async fn create_store(&self) -> Result<Box<dyn CredentialStore>, PasskeyError> {
+        match self {
+            CredentialStoreType::Memory => Ok(Box::new(InMemoryCredentialStore::default())),
+            // CredentialStoreType::Sqlite { path } => {
+            //     Ok(Box::new(SqliteCredentialStore::connect(path).await?))
+            // }
+            // CredentialStoreType::Postgres { url } => {
+            //     Ok(Box::new(PostgresCredentialStore::new(url).await?))
+            // }
+        }
+    }
+}
+
+#[async_trait]
+pub trait ChallengeStore: Send + Sync + 'static {
+    /// Initialize the store. This is called when the store is created.
+    async fn init(&self) -> Result<(), PasskeyError>;
+
+    async fn store_challenge(
+        &mut self,
+        user_id: String,
+        challenge: StoredChallenge,
+    ) -> Result<(), PasskeyError>;
+
+    async fn get_challenge(&self, user_id: &str) -> Result<Option<StoredChallenge>, PasskeyError>;
+
+    async fn remove_challenge(&mut self, user_id: &str) -> Result<(), PasskeyError>;
+}
+
+#[async_trait]
+pub trait CredentialStore: Send + Sync + 'static {
+    /// Initialize the store. This is called when the store is created.
+    async fn init(&self) -> Result<(), PasskeyError>;
+
+    async fn store_credential(
+        &mut self,
+        user_id: String,
+        credential: StoredCredential,
+    ) -> Result<(), PasskeyError>;
+
+    async fn get_credential(&self, user_id: &str)
+        -> Result<Option<StoredCredential>, PasskeyError>;
+
+    async fn update_credential_counter(
+        &mut self,
+        user_id: &str,
+        new_counter: u32,
+    ) -> Result<(), PasskeyError>;
+
+    async fn get_all_credentials(&self) -> Result<Vec<StoredCredential>, PasskeyError>;
+}

--- a/libpasskey/src/storage/memory.rs
+++ b/libpasskey/src/storage/memory.rs
@@ -1,0 +1,80 @@
+use super::{ChallengeStore, CredentialStore};
+use crate::errors::PasskeyError;
+use crate::passkey::{StoredChallenge, StoredCredential};
+use async_trait::async_trait;
+use std::collections::HashMap;
+
+#[derive(Default)]
+pub struct InMemoryChallengeStore {
+    challenges: HashMap<String, StoredChallenge>,
+}
+
+#[derive(Default)]
+pub struct InMemoryCredentialStore {
+    credentials: HashMap<String, StoredCredential>,
+}
+
+#[async_trait]
+impl ChallengeStore for InMemoryChallengeStore {
+    async fn init(&self) -> Result<(), PasskeyError> {
+        Ok(()) // Nothing to initialize for in-memory store
+    }
+
+    async fn store_challenge(
+        &mut self,
+        user_id: String,
+        challenge: StoredChallenge,
+    ) -> Result<(), PasskeyError> {
+        self.challenges.insert(user_id, challenge);
+        Ok(())
+    }
+
+    async fn get_challenge(&self, user_id: &str) -> Result<Option<StoredChallenge>, PasskeyError> {
+        Ok(self.challenges.get(user_id).cloned())
+    }
+
+    async fn remove_challenge(&mut self, user_id: &str) -> Result<(), PasskeyError> {
+        self.challenges.remove(user_id);
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl CredentialStore for InMemoryCredentialStore {
+    async fn init(&self) -> Result<(), PasskeyError> {
+        Ok(()) // Nothing to initialize for in-memory store
+    }
+
+    async fn store_credential(
+        &mut self,
+        user_id: String,
+        credential: StoredCredential,
+    ) -> Result<(), PasskeyError> {
+        self.credentials.insert(user_id, credential);
+        Ok(())
+    }
+
+    async fn get_credential(
+        &self,
+        user_id: &str,
+    ) -> Result<Option<StoredCredential>, PasskeyError> {
+        Ok(self.credentials.get(user_id).cloned())
+    }
+
+    async fn update_credential_counter(
+        &mut self,
+        user_id: &str,
+        new_counter: u32,
+    ) -> Result<(), PasskeyError> {
+        if let Some(credential) = self.credentials.get_mut(user_id) {
+            credential.counter = new_counter;
+            Ok(())
+        } else {
+            Err(PasskeyError::NotFound("Credential not found".to_string()))
+        }
+    }
+
+    async fn get_all_credentials(&self) -> Result<Vec<StoredCredential>, PasskeyError> {
+        Ok(self.credentials.values().cloned().collect())
+    }
+}


### PR DESCRIPTION
- Remove Postgres and SQLite storage implementations temporarily
- Simplify StoredCredential struct by removing unused fields
- Fix async operations in auth and registration flows
- Update error handling to use PasskeyError consistently
- Remove unused AppState::with_stores constructor

This change focuses on getting the core functionality working with in-memory storage before adding persistent storage options back.