### PR TITLE
refactor: remove AppState and simplify storage initialization

### DIFF
--- a/demo-passkey/Cargo.toml
+++ b/demo-passkey/Cargo.toml
@@ -10,3 +10,4 @@ axum-core = "0.5.0"
 tokio = { workspace = true }
 
 libpasskey.workspace = true
+dotenv = "0.15.0"

--- a/demo-passkey/src/main.rs
+++ b/demo-passkey/src/main.rs
@@ -19,12 +19,13 @@ async fn index() -> impl IntoResponse {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let passkey_state = libpasskey::AppState::new().await?;
+    dotenv::dotenv().ok();
+    libpasskey::init().await?;
 
     let app = Router::new()
         .route("/", get(index))
-        .nest("/auth", routes::router_auth(passkey_state.clone()))
-        .nest("/register", routes::router_register(passkey_state.clone()));
+        .nest("/auth", routes::router_auth())
+        .nest("/register", routes::router_register());
 
     println!("Starting server on http://localhost:3001");
     let listener = tokio::net::TcpListener::bind("0.0.0.0:3001").await?;

--- a/demo-passkey/src/routes.rs
+++ b/demo-passkey/src/routes.rs
@@ -1,50 +1,45 @@
 use axum::{
-    extract::{Json, State},
+    extract::Json,
     http::StatusCode,
     routing::post,
     Router,
 };
 use libpasskey::{
-    finish_registration, start_authentication, start_registration, verify_authentication, AppState,
+    finish_registration, start_authentication, start_registration, verify_authentication,
     AuthenticationOptions, AuthenticatorResponse, RegisterCredential, RegistrationOptions,
 };
 
-pub fn router_register(state: AppState) -> Router {
+pub fn router_register() -> Router {
     Router::new()
         .route("/start", post(handle_start_registration))
         .route("/finish", post(handle_finish_registration))
-        .with_state(state)
 }
 
-pub fn router_auth(state: AppState) -> Router {
+pub fn router_auth() -> Router {
     Router::new()
         .route("/start", post(handle_start_authentication))
         .route("/finish", post(handle_finish_authentication))
-        .with_state(state)
 }
 
 async fn handle_start_registration(
-    State(state): State<AppState>,
     Json(username): Json<String>,
 ) -> Json<RegistrationOptions> {
     Json(
-        start_registration(&state, username)
+        start_registration(username)
             .await
             .expect("Failed to start registration"),
     )
 }
 
 async fn handle_finish_registration(
-    State(state): State<AppState>,
     Json(reg_data): Json<RegisterCredential>,
 ) -> Result<String, (StatusCode, String)> {
-    finish_registration(&state, reg_data)
+    finish_registration(reg_data)
         .await
         .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))
 }
 
 async fn handle_start_authentication(
-    State(state): State<AppState>,
     username: Result<Json<String>, axum::extract::rejection::JsonRejection>,
 ) -> Json<AuthenticationOptions> {
     let username = match username {
@@ -53,17 +48,16 @@ async fn handle_start_authentication(
     };
 
     Json(
-        start_authentication(&state, username)
+        start_authentication(username)
             .await
             .expect("Failed to start authentication"),
     )
 }
 
 async fn handle_finish_authentication(
-    State(state): State<AppState>,
     Json(auth_response): Json<AuthenticatorResponse>,
 ) -> Result<String, (StatusCode, String)> {
-    verify_authentication(&state, auth_response)
+    verify_authentication(auth_response)
         .await
         .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))
 }

--- a/libpasskey/Cargo.toml
+++ b/libpasskey/Cargo.toml
@@ -34,3 +34,4 @@ tokio = { workspace = true }
 uuid = { version = "1.13.1", features = ["atomic", "md5", "sha1", "v4"] }
 webpki = { version = "0.22.4", features = ["std"] }
 x509-parser = { version = "0.17.0", features = ["validate", "verify"] }
+tracing = "0.1.41"

--- a/libpasskey/Cargo.toml
+++ b/libpasskey/Cargo.toml
@@ -13,7 +13,7 @@ ciborium = "0.2.2"
 dotenv = "0.15.0"
 oid-registry = "0.8.1"
 redis = { version = "0.28.2", features = ["tokio-comp"] }
-ring = { version = "0.17.8", features = ["std"] }
+ring = { version = "0.17.9", features = ["std"] }
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.138"
 sqlx = { version = "0.8", features = [

--- a/libpasskey/src/axum/handlers.rs
+++ b/libpasskey/src/axum/handlers.rs
@@ -1,6 +1,6 @@
 use askama::Template;
 use axum::{
-    extract::{Json, State},
+    extract::Json,
     http::StatusCode,
     response::Html,
 };
@@ -12,7 +12,6 @@ use crate::passkey::{
 };
 
 use crate::config::PASSKEY_ROUTE_PREFIX;
-use crate::types::AppState;
 
 #[derive(Template)]
 #[template(path = "index.html")]
@@ -28,27 +27,24 @@ pub(crate) async fn index() -> impl IntoResponse {
 }
 
 pub(crate) async fn handle_start_registration(
-    State(state): State<AppState>,
     Json(username): Json<String>,
 ) -> Json<RegistrationOptions> {
     Json(
-        start_registration(&state, username)
+        start_registration(username)
             .await
             .expect("Failed to start registration"),
     )
 }
 
 pub(crate) async fn handle_finish_registration(
-    State(state): State<AppState>,
     Json(reg_data): Json<RegisterCredential>,
 ) -> Result<String, (StatusCode, String)> {
-    finish_registration(&state, reg_data)
+    finish_registration(reg_data)
         .await
         .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))
 }
 
 pub(crate) async fn handle_start_authentication(
-    State(state): State<AppState>,
     username: Result<Json<String>, axum::extract::rejection::JsonRejection>,
 ) -> Json<AuthenticationOptions> {
     let username = match username {
@@ -57,17 +53,16 @@ pub(crate) async fn handle_start_authentication(
     };
 
     Json(
-        start_authentication(&state, username)
+        start_authentication(username)
             .await
             .expect("Failed to start authentication"),
     )
 }
 
 pub(crate) async fn handle_finish_authentication(
-    State(state): State<AppState>,
     Json(auth_response): Json<AuthenticatorResponse>,
 ) -> Result<String, (StatusCode, String)> {
-    verify_authentication(&state, auth_response)
+    verify_authentication(auth_response)
         .await
         .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))
 }

--- a/libpasskey/src/axum/handlers.rs
+++ b/libpasskey/src/axum/handlers.rs
@@ -1,9 +1,5 @@
 use askama::Template;
-use axum::{
-    extract::Json,
-    http::StatusCode,
-    response::Html,
-};
+use axum::{extract::Json, http::StatusCode, response::Html};
 use axum_core::response::IntoResponse;
 
 use crate::passkey::{

--- a/libpasskey/src/axum/routes.rs
+++ b/libpasskey/src/axum/routes.rs
@@ -4,25 +4,22 @@ use super::handlers::{
     handle_finish_authentication, handle_finish_registration, handle_start_authentication,
     handle_start_registration, index,
 };
-use crate::types::AppState;
 
-pub fn router(passkey_state: AppState) -> Router {
+pub fn router() -> Router {
     Router::new()
         .route("/", get(index))
-        .nest("/auth", router_auth(passkey_state.clone()))
-        .nest("/register", router_register(passkey_state))
+        .nest("/auth", router_auth())
+        .nest("/register", router_register())
 }
 
-pub fn router_register(state: AppState) -> Router {
+pub fn router_register() -> Router {
     Router::new()
         .route("/start", post(handle_start_registration))
         .route("/finish", post(handle_finish_registration))
-        .with_state(state)
 }
 
-pub fn router_auth(state: AppState) -> Router {
+pub fn router_auth() -> Router {
     Router::new()
         .route("/start", post(handle_start_authentication))
         .route("/finish", post(handle_finish_authentication))
-        .with_state(state)
 }

--- a/libpasskey/src/common.rs
+++ b/libpasskey/src/common.rs
@@ -1,12 +1,7 @@
 use base64::engine::{general_purpose::URL_SAFE, Engine};
 use ring::rand::SecureRandom;
-use std::sync::Arc;
-use tokio::sync::Mutex;
 
 use crate::errors::PasskeyError;
-use crate::passkey::Config;
-use crate::storage::{ChallengeStoreType, CredentialStoreType};
-use crate::types::AppState;
 
 pub(crate) fn base64url_decode(input: &str) -> Result<Vec<u8>, PasskeyError> {
     let padding_len = (4 - input.len() % 4) % 4;
@@ -23,25 +18,4 @@ pub(crate) fn generate_challenge() -> Result<Vec<u8>, PasskeyError> {
     rng.fill(&mut challenge)
         .map_err(|_| PasskeyError::Crypto("Failed to generate random challenge".to_string()))?;
     Ok(challenge)
-}
-
-// Public things
-impl AppState {
-    pub async fn new() -> Result<Self, PasskeyError> {
-        let config = Config::from_env()?;
-        config.validate()?;
-
-        let challenge_store = ChallengeStoreType::from_env()?.create_store().await?;
-        let credential_store = CredentialStoreType::from_env()?.create_store().await?;
-
-        // Initialize the stores
-        challenge_store.init().await?;
-        credential_store.init().await?;
-
-        Ok(Self {
-            challenge_store: Arc::new(Mutex::new(challenge_store)),
-            credential_store: Arc::new(Mutex::new(credential_store)),
-            config,
-        })
-    }
 }

--- a/libpasskey/src/config.rs
+++ b/libpasskey/src/config.rs
@@ -1,8 +1,119 @@
-use std::env;
-use std::sync::LazyLock;
+use std::{env, sync::LazyLock};
+use tokio::sync::Mutex;
 
 use crate::errors::PasskeyError;
-use crate::passkey::{AuthenticatorSelection, Config};
+use crate::storage::{
+    ChallengeStore, ChallengeStoreType, CredentialStore, CredentialStoreType,
+    InMemoryChallengeStore, InMemoryCredentialStore,
+};
+
+pub(crate) struct SingletonChallengeStore {
+    store: Box<dyn ChallengeStore>,
+    initialized: bool,
+}
+
+impl SingletonChallengeStore {
+    fn new(store: Box<dyn ChallengeStore>) -> Self {
+        Self {
+            store,
+            initialized: false,
+        }
+    }
+
+    fn set_store(&mut self, new_store: Box<dyn ChallengeStore>) -> Result<(), PasskeyError> {
+        if self.initialized {
+            return Err(PasskeyError::Storage(
+                "Challenge store has already been initialized".to_string(),
+            ));
+        }
+        self.store = new_store;
+        self.initialized = true;
+        Ok(())
+    }
+
+    pub(crate) fn get_store(&self) -> &dyn ChallengeStore {
+        &*self.store
+    }
+
+    pub(crate) fn get_store_mut(&mut self) -> &mut Box<dyn ChallengeStore> {
+        &mut self.store
+    }
+}
+
+pub(crate) static PASSKEY_CHALLENGE_STORE: LazyLock<Mutex<SingletonChallengeStore>> =
+    LazyLock::new(|| {
+        Mutex::new(SingletonChallengeStore::new(Box::new(
+            InMemoryChallengeStore::new(),
+        )))
+    });
+
+pub(crate) async fn init_challenge_store() -> Result<(), PasskeyError> {
+    let store_type = ChallengeStoreType::from_env().unwrap_or_else(|e| {
+        eprintln!("Failed to initialize token store from environment: {}", e);
+        eprintln!("Falling back to in-memory store");
+        ChallengeStoreType::Memory
+    });
+
+    tracing::info!("Initializing token store with type: {:?}", store_type);
+    let store = store_type.create_store().await?;
+    PASSKEY_CHALLENGE_STORE.lock().await.set_store(store)?;
+    tracing::info!("Token store initialized successfully");
+    Ok(())
+}
+
+pub(crate) struct SingletonCredentialStore {
+    store: Box<dyn CredentialStore>,
+    initialized: bool,
+}
+
+impl SingletonCredentialStore {
+    fn new(store: Box<dyn CredentialStore>) -> Self {
+        Self {
+            store,
+            initialized: false,
+        }
+    }
+
+    fn set_store(&mut self, new_store: Box<dyn CredentialStore>) -> Result<(), PasskeyError> {
+        if self.initialized {
+            return Err(PasskeyError::Storage(
+                "Credential store has already been initialized".to_string(),
+            ));
+        }
+        self.store = new_store;
+        self.initialized = true;
+        Ok(())
+    }
+
+    pub(crate) fn get_store(&self) -> &dyn CredentialStore {
+        &*self.store
+    }
+
+    pub(crate) fn get_store_mut(&mut self) -> &mut Box<dyn CredentialStore> {
+        &mut self.store
+    }
+}
+
+pub(crate) static PASSKEY_CREDENTIAL_STORE: LazyLock<Mutex<SingletonCredentialStore>> =
+    LazyLock::new(|| {
+        Mutex::new(SingletonCredentialStore::new(Box::new(
+            InMemoryCredentialStore::new(),
+        )))
+    });
+
+pub(crate) async fn init_credential_store() -> Result<(), PasskeyError> {
+    let store_type = CredentialStoreType::from_env().unwrap_or_else(|e| {
+        eprintln!("Failed to initialize token store from environment: {}", e);
+        eprintln!("Falling back to in-memory store");
+        CredentialStoreType::Memory
+    });
+
+    tracing::info!("Initializing token store with type: {:?}", store_type);
+    let store = store_type.create_store().await?;
+    PASSKEY_CREDENTIAL_STORE.lock().await.set_store(store)?;
+    tracing::info!("Token store initialized successfully");
+    Ok(())
+}
 
 pub static PASSKEY_ROUTE_PREFIX: LazyLock<String> = LazyLock::new(|| {
     std::env::var("PASSKEY_ROUTE_PREFIX")
@@ -10,129 +121,225 @@ pub static PASSKEY_ROUTE_PREFIX: LazyLock<String> = LazyLock::new(|| {
         .unwrap_or("/passkey".to_string())
 });
 
-impl Config {
-    /// Creates a new Config instance from environment variables
-    pub fn from_env() -> Result<Self, PasskeyError> {
-        dotenv::dotenv().ok();
+pub(crate) static ORIGIN: LazyLock<String> =
+    LazyLock::new(|| std::env::var("ORIGIN").expect("ORIGIN must be set"));
 
-        let origin = env::var("ORIGIN")
-            .map_err(|_| PasskeyError::Config("ORIGIN must be set".to_string()))?;
+pub(crate) static PASSKEY_RP_ID: LazyLock<String> = LazyLock::new(|| {
+    ORIGIN
+        .trim_start_matches("https://")
+        .trim_start_matches("http://")
+        .split(':')
+        .next()
+        .map(|s| s.to_string())
+        .expect("Could not extract RP ID from ORIGIN")
+});
 
-        let rp_id = origin
-            .trim_start_matches("https://")
-            .trim_start_matches("http://")
-            .split(':')
-            .next()
-            .unwrap_or(&origin)
-            .to_string();
+pub(crate) static PASSKEY_RP_NAME: LazyLock<String> =
+    LazyLock::new(|| env::var("PASSKEY_RP_NAME").ok().unwrap_or(ORIGIN.clone()));
 
-        let rp_name = env::var("PASSKEY_RP_NAME").unwrap_or(origin.clone());
+pub(crate) static PASSKEY_TIMEOUT: LazyLock<u32> = LazyLock::new(|| {
+    env::var("PASSKEY_TIMEOUT")
+        .map(|v| v.parse::<u32>().unwrap_or(60))
+        .unwrap_or(60)
+});
 
-        let timeout = env::var("PASSKEY_TIMEOUT")
-            .map(|v| v.parse::<u32>())
-            .unwrap_or(Ok(60))
-            .map_err(|e| PasskeyError::Config(format!("Invalid timeout value: {}", e)))?;
+pub(crate) static PASSKEY_CHALLENGE_TIMEOUT: LazyLock<u32> = LazyLock::new(|| {
+    env::var("PASSKEY_CHALLENGE_TIMEOUT")
+        .map(|v| v.parse::<u32>().unwrap_or(60))
+        .unwrap_or(60)
+});
 
-        let challenge_timeout = env::var("PASSKEY_CHALLENGE_TIMEOUT")
-            .map(|v| v.parse::<u64>())
-            .unwrap_or(Ok(60))
-            .map_err(|e| PasskeyError::Config(format!("Invalid challenge timeout value: {}", e)))?;
+pub(crate) static PASSKEY_AUTHENTICATOR_ATTACHMENT: LazyLock<String> = LazyLock::new(|| {
+    match env::var("PASSKEY_AUTHENTICATOR_ATTACHMENT").ok() {
+        None => "platform".to_string(),
+        Some(v) => match v.to_lowercase().as_str() {
+            "platform" => "platform".to_string(),
+            "cross-platform" => "cross-platform".to_string(),
+            "none" => "None".to_string(), // Ensure "None" is capitalized
+            invalid => {
+                tracing::warn!(
+                    "Invalid authenticator attachment: {}. Using default 'platform'",
+                    invalid
+                );
+                "platform".to_string()
+            }
+        },
+    }
+});
 
-        let _authenticator_attachment = env::var("PASSKEY_AUTHENTICATOR_ATTACHMENT").map_or(
-        Ok("platform".to_string()), // Default to platform
+pub(crate) static PASSKEY_RESIDENT_KEY: LazyLock<String> = LazyLock::new(|| {
+    env::var("PASSKEY_RESIDENT_KEY").map_or(
+        "required".to_string(), // Default to required
         |v| match v.to_lowercase().as_str() {
-            "platform" => Ok("platform".to_string()),
-            "cross-platform" => Ok("cross-platform".to_string()),
-            "none" => Ok("None".to_string()),
-            invalid => Err(PasskeyError::Config(format!(
-                "Invalid authenticator attachment: {}. Valid values are: platform, cross-platform, None",
-                invalid
-            ))),
-        })?;
+            "required" => "required".to_string(),
+            "preferred" => "preferred".to_string(),
+            "discouraged" => "discouraged".to_string(),
+            _ => {
+                tracing::warn!("Invalid user verification: {}. Using default 'required'", v);
+                "required".to_string()
+            }
+        },
+    )
+});
 
-        let authenticator_attachment = match env::var("PASSKEY_AUTHENTICATOR_ATTACHMENT").ok() {
-            None => Ok("platform".to_string()),
-            Some(v) => match v.to_lowercase().as_str() {
-                "platform" => Ok("platform".to_string()),
-                "cross-platform" => Ok("cross-platform".to_string()),
-                "none" => Ok("None".to_string()), // Ensure "None" is capitalized
-                invalid => Err(PasskeyError::Config(format!(
-                    "Invalid authenticator attachment: {}.
-                    Valid values are: platform, cross-platform, none",
+pub(crate) static PASSKEY_REQUIRE_RESIDENT_KEY: LazyLock<bool> = LazyLock::new(|| {
+    env::var("PASSKEY_REQUIRE_RESIDENT_KEY").map_or(
+        true, // Default to true
+        |v| match v.to_lowercase().as_str() {
+            "true" => true,
+            "false" => false,
+            invalid => {
+                tracing::warn!(
+                    "Invalid require_resident_key: {}. Using default 'true'",
                     invalid
-                ))),
-            },
-        }?;
+                );
+                true
+            }
+        },
+    )
+});
 
-        let resident_key = env::var("PASSKEY_RESIDENT_KEY").map_or(
-            Ok("required".to_string()), // Default to required
-            |v| match v.to_lowercase().as_str() {
-                "required" => Ok("required".to_string()),
-                "preferred" => Ok("preferred".to_string()),
-                "discouraged" => Ok("discouraged".to_string()),
-                invalid => Err(PasskeyError::Config(format!(
-                    "Invalid resident key: {}. Valid values are: required, preferred, discouraged",
-                    invalid
-                ))),
-            },
-        )?;
+pub(crate) static PASSKEY_USER_VERIFICATION: LazyLock<String> = LazyLock::new(|| {
+    env::var("PASSKEY_USER_VERIFICATION").map_or(
+        "discouraged".to_string(), // Default to discouraged
+        |v| match v.to_lowercase().as_str() {
+            "required" => "required".to_string(),
+            "preferred" => "preferred".to_string(),
+            "discouraged" => "discouraged".to_string(),
+            _ => {
+                tracing::warn!(
+                    "Invalid user verification: {}. Using default 'discouraged'",
+                    v
+                );
+                "discouraged".to_string()
+            }
+        },
+    )
+});
 
-        let require_resident_key = env::var("PASSKEY_REQUIRE_RESIDENT_KEY").map_or(
-            Ok(true), // Default to true
-            |v| match v.to_lowercase().as_str() {
-                "true" => Ok(true),
-                "false" => Ok(false),
-                invalid => Err(PasskeyError::Config(format!(
-                    "Invalid require_resident_key: {}. Valid values are: true, false",
-                    invalid
-                ))),
-            },
-        )?;
+// impl Config {
+//     /// Creates a new Config instance from environment variables
+//     pub fn from_env() -> Result<Self, PasskeyError> {
+//         dotenv::dotenv().ok();
 
-        let user_verification = env::var("PASSKEY_USER_VERIFICATION").map_or(
-            Ok("discouraged".to_string()), // Default to discouraged
-            |v| match v.to_lowercase().as_str() {
-                "required" => Ok("required".to_string()),
-                "preferred" => Ok("preferred".to_string()),
-                "discouraged" => Ok("discouraged".to_string()),
-                invalid => Err(PasskeyError::Config(format!(
-                    "Invalid user verification: {}. Valid values are: required, preferred, discouraged",
-                    invalid
-                ))),
-            },
-        )?;
+//         let origin = env::var("ORIGIN")
+//             .map_err(|_| PasskeyError::Config("ORIGIN must be set".to_string()))?;
 
-        Ok(Config {
-            origin,
-            rp_id,
-            rp_name,
-            timeout,
-            challenge_timeout_seconds: challenge_timeout,
-            authenticator_selection: AuthenticatorSelection {
-                authenticator_attachment,
-                resident_key,
-                require_resident_key,
-                user_verification,
-            },
-        })
-    }
+//         let rp_id = origin
+//             .trim_start_matches("https://")
+//             .trim_start_matches("http://")
+//             .split(':')
+//             .next()
+//             .unwrap_or(&origin)
+//             .to_string();
 
-    /// Validates the configuration
-    pub fn validate(&self) -> Result<(), PasskeyError> {
-        if self.origin.is_empty() {
-            return Err(PasskeyError::Config("Origin cannot be empty".to_string()));
-        }
-        if self.rp_id.is_empty() {
-            return Err(PasskeyError::Config("RP ID cannot be empty".to_string()));
-        }
-        if self.timeout == 0 {
-            return Err(PasskeyError::Config("Timeout cannot be zero".to_string()));
-        }
-        if self.challenge_timeout_seconds == 0 {
-            return Err(PasskeyError::Config(
-                "Challenge timeout cannot be zero".to_string(),
-            ));
-        }
-        Ok(())
-    }
-}
+//         let rp_name = env::var("PASSKEY_RP_NAME").unwrap_or(origin.clone());
+
+//         let timeout = env::var("PASSKEY_TIMEOUT")
+//             .map(|v| v.parse::<u32>())
+//             .unwrap_or(Ok(60))
+//             .map_err(|e| PasskeyError::Config(format!("Invalid timeout value: {}", e)))?;
+
+//         let challenge_timeout = env::var("PASSKEY_CHALLENGE_TIMEOUT")
+//             .map(|v| v.parse::<u64>())
+//             .unwrap_or(Ok(60))
+//             .map_err(|e| PasskeyError::Config(format!("Invalid challenge timeout value: {}", e)))?;
+
+//         let _authenticator_attachment = env::var("PASSKEY_AUTHENTICATOR_ATTACHMENT").map_or(
+//         Ok("platform".to_string()), // Default to platform
+//         |v| match v.to_lowercase().as_str() {
+//             "platform" => Ok("platform".to_string()),
+//             "cross-platform" => Ok("cross-platform".to_string()),
+//             "none" => Ok("None".to_string()),
+//             invalid => Err(PasskeyError::Config(format!(
+//                 "Invalid authenticator attachment: {}. Valid values are: platform, cross-platform, None",
+//                 invalid
+//             ))),
+//         })?;
+
+//         let authenticator_attachment = match env::var("PASSKEY_AUTHENTICATOR_ATTACHMENT").ok() {
+//             None => Ok("platform".to_string()),
+//             Some(v) => match v.to_lowercase().as_str() {
+//                 "platform" => Ok("platform".to_string()),
+//                 "cross-platform" => Ok("cross-platform".to_string()),
+//                 "none" => Ok("None".to_string()), // Ensure "None" is capitalized
+//                 invalid => Err(PasskeyError::Config(format!(
+//                     "Invalid authenticator attachment: {}.
+//                     Valid values are: platform, cross-platform, none",
+//                     invalid
+//                 ))),
+//             },
+//         }?;
+
+//         let resident_key = env::var("PASSKEY_RESIDENT_KEY").map_or(
+//             Ok("required".to_string()), // Default to required
+//             |v| match v.to_lowercase().as_str() {
+//                 "required" => Ok("required".to_string()),
+//                 "preferred" => Ok("preferred".to_string()),
+//                 "discouraged" => Ok("discouraged".to_string()),
+//                 invalid => Err(PasskeyError::Config(format!(
+//                     "Invalid resident key: {}. Valid values are: required, preferred, discouraged",
+//                     invalid
+//                 ))),
+//             },
+//         )?;
+
+//         let require_resident_key = env::var("PASSKEY_REQUIRE_RESIDENT_KEY").map_or(
+//             Ok(true), // Default to true
+//             |v| match v.to_lowercase().as_str() {
+//                 "true" => Ok(true),
+//                 "false" => Ok(false),
+//                 invalid => Err(PasskeyError::Config(format!(
+//                     "Invalid require_resident_key: {}. Valid values are: true, false",
+//                     invalid
+//                 ))),
+//             },
+//         )?;
+
+//         let user_verification = env::var("PASSKEY_USER_VERIFICATION").map_or(
+//             Ok("discouraged".to_string()), // Default to discouraged
+//             |v| match v.to_lowercase().as_str() {
+//                 "required" => Ok("required".to_string()),
+//                 "preferred" => Ok("preferred".to_string()),
+//                 "discouraged" => Ok("discouraged".to_string()),
+//                 invalid => Err(PasskeyError::Config(format!(
+//                     "Invalid user verification: {}. Valid values are: required, preferred, discouraged",
+//                     invalid
+//                 ))),
+//             },
+//         )?;
+
+//         Ok(Config {
+//             origin,
+//             rp_id,
+//             rp_name,
+//             timeout,
+//             challenge_timeout_seconds: challenge_timeout,
+//             authenticator_selection: AuthenticatorSelection {
+//                 authenticator_attachment,
+//                 resident_key,
+//                 require_resident_key,
+//                 user_verification,
+//             },
+//         })
+//     }
+
+//     /// Validates the configuration
+//     pub fn validate(&self) -> Result<(), PasskeyError> {
+//         if self.origin.is_empty() {
+//             return Err(PasskeyError::Config("Origin cannot be empty".to_string()));
+//         }
+//         if self.rp_id.is_empty() {
+//             return Err(PasskeyError::Config("RP ID cannot be empty".to_string()));
+//         }
+//         if self.timeout == 0 {
+//             return Err(PasskeyError::Config("Timeout cannot be zero".to_string()));
+//         }
+//         if self.challenge_timeout_seconds == 0 {
+//             return Err(PasskeyError::Config(
+//                 "Challenge timeout cannot be zero".to_string(),
+//             ));
+//         }
+//         Ok(())
+//     }
+// }

--- a/libpasskey/src/lib.rs
+++ b/libpasskey/src/lib.rs
@@ -11,7 +11,7 @@ mod types;
 // };
 // pub(crate) use errors::PasskeyError;
 
-pub use types::AppState;
+// pub use types::AppState;
 
 pub use axum::router;
 pub use config::PASSKEY_ROUTE_PREFIX; // Required for route configuration
@@ -20,3 +20,12 @@ pub use passkey::{
     finish_registration, start_authentication, start_registration, verify_authentication,
     AuthenticationOptions, AuthenticatorResponse, RegisterCredential, RegistrationOptions,
 };
+
+pub async fn init() -> Result<(), errors::PasskeyError> {
+    // Validate required environment variables early
+    let _ = *config::PASSKEY_RP_ID;
+
+    config::init_challenge_store().await?;
+    config::init_credential_store().await?;
+    Ok(())
+}

--- a/libpasskey/src/passkey/mod.rs
+++ b/libpasskey/src/passkey/mod.rs
@@ -4,7 +4,7 @@ mod register;
 mod types;
 
 pub use types::{
-    AuthenticationOptions, AuthenticatorResponse,     RegisterCredential, RegistrationOptions,
+    AuthenticationOptions, AuthenticatorResponse, RegisterCredential, RegistrationOptions,
 };
 
 pub use auth::{start_authentication, verify_authentication};

--- a/libpasskey/src/passkey/mod.rs
+++ b/libpasskey/src/passkey/mod.rs
@@ -4,8 +4,7 @@ mod register;
 mod types;
 
 pub use types::{
-    AuthenticationOptions, AuthenticatorResponse, AuthenticatorSelection, Config,
-    RegisterCredential, RegistrationOptions,
+    AuthenticationOptions, AuthenticatorResponse,     RegisterCredential, RegistrationOptions,
 };
 
 pub use auth::{start_authentication, verify_authentication};

--- a/libpasskey/src/passkey/types.rs
+++ b/libpasskey/src/passkey/types.rs
@@ -19,16 +19,6 @@ pub(super) struct AllowCredential {
     pub(super) id: Vec<u8>,
 }
 
-#[derive(Clone, Debug)]
-pub struct Config {
-    pub(crate) origin: String,
-    pub(crate) rp_id: String,
-    pub(crate) rp_name: String,
-    pub(crate) authenticator_selection: AuthenticatorSelection,
-    pub(crate) timeout: u32,
-    pub(crate) challenge_timeout_seconds: u64,
-}
-
 #[derive(Serialize, Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AuthenticatorSelection {

--- a/libpasskey/src/storage/mod.rs
+++ b/libpasskey/src/storage/mod.rs
@@ -6,4 +6,6 @@ mod traits;
 mod types;
 
 pub(crate) use traits::{ChallengeStore, CredentialStore};
-pub(crate) use types::{ChallengeStoreType, CredentialStoreType};
+pub(crate) use types::{
+    ChallengeStoreType, CredentialStoreType, InMemoryChallengeStore, InMemoryCredentialStore,
+};

--- a/libpasskey/src/storage/traits.rs
+++ b/libpasskey/src/storage/traits.rs
@@ -46,19 +46,22 @@ impl ChallengeStoreType {
     }
 
     pub(crate) async fn create_store(&self) -> Result<Box<dyn ChallengeStore>, PasskeyError> {
-        match self {
-            ChallengeStoreType::Memory => Ok(Box::new(InMemoryChallengeStore::new())),
+        let store: Box<dyn ChallengeStore> = match self {
+            ChallengeStoreType::Memory => Box::new(InMemoryChallengeStore::new()),
             ChallengeStoreType::Sqlite { url } => {
-                Ok(Box::new(SqliteChallengeStore::connect(url).await?))
+                Box::new(SqliteChallengeStore::connect(url).await?)
             }
             ChallengeStoreType::Postgres { url } => {
-                Ok(Box::new(PostgresChallengeStore::connect(url).await?))
+                Box::new(PostgresChallengeStore::connect(url).await?)
             }
             ChallengeStoreType::Redis { url } => {
-                Ok(Box::new(RedisChallengeStore::connect(url).await?))
+                Box::new(RedisChallengeStore::connect(url).await?)
             }
-        }
+        };
+        store.init().await?;
+        Ok(store)
     }
+
 }
 
 impl CredentialStoreType {
@@ -96,18 +99,20 @@ impl CredentialStoreType {
     }
 
     pub(crate) async fn create_store(&self) -> Result<Box<dyn CredentialStore>, PasskeyError> {
-        match self {
-            CredentialStoreType::Memory => Ok(Box::new(InMemoryCredentialStore::new())),
+        let store: Box<dyn CredentialStore> = match self {
+            CredentialStoreType::Memory => Box::new(InMemoryCredentialStore::new()),
             CredentialStoreType::Sqlite { url } => {
-                Ok(Box::new(SqliteCredentialStore::connect(url).await?))
+                Box::new(SqliteCredentialStore::connect(url).await?)
             }
             CredentialStoreType::Postgres { url } => {
-                Ok(Box::new(PostgresCredentialStore::connect(url).await?))
+                Box::new(PostgresCredentialStore::connect(url).await?)
             }
             CredentialStoreType::Redis { url } => {
-                Ok(Box::new(RedisCredentialStore::connect(url).await?))
+                Box::new(RedisCredentialStore::connect(url).await?)
             }
-        }
+        };
+        store.init().await?;
+        Ok(store)
     }
 }
 

--- a/libpasskey/src/storage/traits.rs
+++ b/libpasskey/src/storage/traits.rs
@@ -54,14 +54,11 @@ impl ChallengeStoreType {
             ChallengeStoreType::Postgres { url } => {
                 Box::new(PostgresChallengeStore::connect(url).await?)
             }
-            ChallengeStoreType::Redis { url } => {
-                Box::new(RedisChallengeStore::connect(url).await?)
-            }
+            ChallengeStoreType::Redis { url } => Box::new(RedisChallengeStore::connect(url).await?),
         };
         store.init().await?;
         Ok(store)
     }
-
 }
 
 impl CredentialStoreType {

--- a/libpasskey/src/types.rs
+++ b/libpasskey/src/types.rs
@@ -1,9 +1,4 @@
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
-use tokio::sync::Mutex;
-
-use crate::passkey::Config;
-use crate::storage::{ChallengeStore, CredentialStore};
 
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
 pub(super) struct PublicKeyCredentialUserEntity {
@@ -27,11 +22,4 @@ pub(super) struct StoredCredential {
     pub(super) public_key: Vec<u8>,
     pub(super) counter: u32,
     pub(super) user: PublicKeyCredentialUserEntity,
-}
-
-#[derive(Clone)]
-pub struct AppState {
-    pub(super) challenge_store: Arc<Mutex<Box<dyn ChallengeStore>>>,
-    pub(super) credential_store: Arc<Mutex<Box<dyn CredentialStore>>>,
-    pub(super) config: Config,
 }


### PR DESCRIPTION
- Remove AppState struct and its dependencies from handlers
- Remove state parameter from axum router and handlers
- Add init() call after store creation for proper initialization
- Add tracing dependency for better logging support
- Improve error handling in store creation
- Move store-related types to dedicated modules
- Adjust visibility modifiers for better encapsulation

This change simplifies the library's architecture by removing the need for state management at the application level, making it easier to use and maintain. Storage initialization is now handled internally.