### PR TITLE
refactor: extract email_to_user_id and use name instead of display_name

### DIFF
--- a/libpasskey/src/common.rs
+++ b/libpasskey/src/common.rs
@@ -1,7 +1,9 @@
 use base64::engine::{general_purpose::URL_SAFE, Engine};
 use ring::rand::SecureRandom;
 
+use crate::config::PASSKEY_CACHE_STORE;
 use crate::errors::PasskeyError;
+use crate::types::CacheData;
 
 pub(crate) fn base64url_decode(input: &str) -> Result<Vec<u8>, PasskeyError> {
     let padding_len = (4 - input.len() % 4) % 4;
@@ -26,4 +28,20 @@ pub(crate) fn gen_random_string(len: usize) -> Result<String, PasskeyError> {
     rng.fill(&mut session_id)
         .map_err(|_| PasskeyError::Crypto("Failed to generate random string".to_string()))?;
     Ok(URL_SAFE.encode(session_id))
+}
+
+pub async fn email_to_user_id(username: String) -> Result<String, PasskeyError> {
+    let user_id = PASSKEY_CACHE_STORE
+        .lock()
+        .await
+        .get_store()
+        .get(&username)
+        .await?
+        .ok_or(PasskeyError::Storage("User not found".into()))?;
+    let user_id = match user_id {
+        CacheData::EmailUserId(id) => Ok(id.user_id),
+        _ => Err(PasskeyError::Format("Invalid user type".to_string())),
+    };
+    let user_id = user_id?;
+    Ok(user_id)
 }

--- a/libpasskey/src/lib.rs
+++ b/libpasskey/src/lib.rs
@@ -22,6 +22,8 @@ pub use passkey::{
     AuthenticationOptions, AuthenticatorResponse, RegisterCredential, RegistrationOptions,
 };
 
+pub use common::email_to_user_id;
+
 pub async fn init() -> Result<(), errors::PasskeyError> {
     // Validate required environment variables early
     let _ = *config::PASSKEY_RP_ID;

--- a/libpasskey/src/passkey/register.rs
+++ b/libpasskey/src/passkey/register.rs
@@ -24,7 +24,8 @@ use crate::types::{
 pub async fn start_registration(username: String) -> Result<RegistrationOptions, PasskeyError> {
     println!("start_registration user: {}", username);
 
-    let user_info = PublicKeyCredentialUserEntity {        id_handle: crate::common::gen_random_string(16)?,
+    let user_info = PublicKeyCredentialUserEntity {
+        id_handle: crate::common::gen_random_string(16)?,
         name: username.clone(),
         display_name: username.clone(),
     };
@@ -121,7 +122,6 @@ pub async fn finish_registration_with_auth_user(
     user: SessionUser,
     reg_data: RegisterCredential,
 ) -> Result<String, PasskeyError> {
-
     let user_handle = reg_data
         .user_handle
         .as_deref()


### PR DESCRIPTION
- Extract common email_to_user_id functionality to common.rs
- Re-export email_to_user_id in lib.rs for public use
- Modify auth verification to return name instead of display_name
- Fix formatting in register.rs